### PR TITLE
POST処理追加

### DIFF
--- a/api/cruds/task.py
+++ b/api/cruds/task.py
@@ -3,9 +3,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import api.models.task as task_model
 import api.schemas.task as task_schema
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from sqlalchemy import select
 from sqlalchemy.engine import Result
+from uuid import UUID
+
+from datetime import datetime
 
 async def create_task(
     db: AsyncSession, task_create: task_schema.TaskCreate
@@ -33,3 +36,25 @@ async def get_tasks_with_done(db: AsyncSession) -> List[Tuple[int, str, bool]]:
         )
     )
     return result.all()
+
+async def get_task(db: AsyncSession, task_id: UUID) -> Optional[task_model.Task]:
+    result: Result = await db.execute(
+        select(task_model.Task).filter(task_model.Task.id == task_id)
+    )
+    task: Optional[Tuple[task_model.Task]] = result.first()
+    return task[0] if task is not None else None  # 要素が一つであってもtupleで返却されるので１つ目の要素を取り出す
+
+async def update_task(
+    db: AsyncSession, task_create: task_schema.TaskCreate, original: task_model.Task
+) -> task_model.Task:
+    original.task = task_create.task
+    original.sort_key = task_create.sort_key
+    original.due_date = task_create.due_date
+    original.complete_date = task_create.complete_date
+    original.is_done = task_create.is_done
+    original.update_at = datetime.now()
+    
+    db.add(original)
+    await db.commit()
+    await db.refresh(original)
+    return original

--- a/api/router/tasks.py
+++ b/api/router/tasks.py
@@ -1,8 +1,8 @@
 # from fastapi import APIRouter
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
-
+from uuid import UUID
 import api.schemas.task as task_schema
 import api.cruds.task as task_crud
 from api.db import get_db
@@ -23,8 +23,14 @@ async def create_task(
 ):
     return await task_crud.create_task(db, task_body)
 @router.put("/todo/{id}")
-async def edit_task():
-    pass
+async def edit_task(
+   task_id: UUID, task_body: task_schema.TaskCreate, db: AsyncSession = Depends(get_db)
+):
+    task = await task_crud.get_task(db, task_id=task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    return await task_crud.update_task(db, task_body, original=task)    
 
 @router.delete("/todo/{id}")
 async def delete_task():


### PR DESCRIPTION
#27

@takasaki376 さん

POST処理を完成したので連絡します。

レスポンスは下記のようなJSONが返ります。

```json
{
  "sort_key": 0,
  "task": "温泉",
  "id": "abbe2bbb-60b5-45ab-8e10-a87c3926d066",
  "complete_date": "2022-03-28",
  "create_at": "2022-04-10T10:12:31.638098",
  "update_at": "2022-04-12T14:25:19.900340",
  "user_id": "1835047b-3c99-45ab-a8e7-089de2c60884",
  "due_date": "2022-03-01",
  "is_done": false
}
```

上記仕様の

>レスポンスは、テーブルの全項目を返す。

ですが、[テーブルレイアウト](https://github.com/mo-ri-regen/qin-todo-backend/wiki/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%A2%E3%83%87%E3%83%AB%E3%81%A8%E7%94%BB%E9%9D%A2%E8%A1%A8%E7%A4%BA%EF%BC%88%E3%82%BF%E3%82%B9%E3%82%AF%EF%BC%89)のU列のレスポンスが●の項目が全部返ってくる(今回は全部)という認識であってます?

それでよければ条件を満たしていると思います。

